### PR TITLE
Bump up version

### DIFF
--- a/PagerCall.xcodeproj/project.pbxproj
+++ b/PagerCall.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 				CODE_SIGN_ENTITLEMENTS = PagerCall/PagerCall.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = YES;
@@ -318,7 +318,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.winebarrel.PagerCall;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -334,7 +334,7 @@
 				CODE_SIGN_ENTITLEMENTS = PagerCall/PagerCall.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = YES;
@@ -351,7 +351,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.winebarrel.PagerCall;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
This pull request updates the project versioning information in the `PagerCall.xcodeproj/project.pbxproj` file. The main changes are to the marketing and project version numbers.

**Versioning updates:**

* Updated `MARKETING_VERSION` from `1.7.0` to `1.8.0` to reflect a new release version. [[1]](diffhunk://#diff-a45809b7c6c01f881ddaa04af8eda396c9bb22cfeac0bb7f6874b44864a510f3L321-R321) [[2]](diffhunk://#diff-a45809b7c6c01f881ddaa04af8eda396c9bb22cfeac0bb7f6874b44864a510f3L354-R354)
* Reset `CURRENT_PROJECT_VERSION` from `3` to `1`, possibly to align with a new versioning scheme or release cycle. [[1]](diffhunk://#diff-a45809b7c6c01f881ddaa04af8eda396c9bb22cfeac0bb7f6874b44864a510f3L304-R304) [[2]](diffhunk://#diff-a45809b7c6c01f881ddaa04af8eda396c9bb22cfeac0bb7f6874b44864a510f3L337-R337)