### PR TITLE
Use URL.appending(path:) instead of string interpolation

### DIFF
--- a/PagerCall/RightClickMenuView.swift
+++ b/PagerCall/RightClickMenuView.swift
@@ -9,14 +9,15 @@ struct RightClickMenuView: View {
         Button("My Incidents") {
             Task {
                 let base = region.webBaseURL(subdomain: subdomain)
-                let url = URL(string: "\(base.absoluteString)/incidents?assignedToUser=\(userID)")!
+                let url = base.appending(path: "incidents")
+                    .appending(queryItems: [URLQueryItem(name: "assignedToUser", value: userID)])
                 NSWorkspace.shared.open(url)
             }
         }
         Button("My On-Call Shifts") {
             Task {
                 let base = region.webBaseURL(subdomain: subdomain)
-                let url = URL(string: "\(base.absoluteString)/my-on-call/week")!
+                let url = base.appending(path: "my-on-call/week")
                 NSWorkspace.shared.open(url)
             }
         }


### PR DESCRIPTION
## Summary

`RightClickMenuView` の URL 生成を、文字列補間 + force-unwrap から `URL.appending(path:)` に置き換えました。

- `my-on-call/week`: `appending(path:)` に変更
- `incidents`: パスを `appending(path:)`、クエリを `URLQueryItem` にして `userID` を自動で percent-encode

どちらも `URL(string:)!` の force-unwrap を解消しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)