### PR TITLE
Add SwiftFormat check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,17 @@ jobs:
           version: latest
           args: --strict
 
+  format:
+    name: Format
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install SwiftFormat
+        run: brew install swiftformat
+      - name: Check formatting
+        run: swiftformat --lint PagerCall
+
   build:
     name: Build and Analyse
     runs-on: macos-26

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,9 @@
 disabled_rules:
   - line_length
   - nesting
+# Require trailing commas to match SwiftFormat's trailingCommas rule.
+trailing_comma:
+  mandatory_comma: true
 analyzer_rules:
   - unused_declaration
   - unused_import

--- a/PagerCall/PagerDutyAPI.swift
+++ b/PagerCall/PagerDutyAPI.swift
@@ -77,7 +77,7 @@ struct PagerDutyAPI {
                 "statuses[]": ["triggered", "acknowledged"],
                 "limit": ["100"],
                 "offset": [String(offset)],
-                "sort_by": [sortBy.rawValue]
+                "sort_by": [sortBy.rawValue],
             ])
             let resp = try decoder.decode(IncidentsResp.self, from: data)
             incidents += resp.incidents

--- a/PagerCall/PreActionButtonStyle.swift
+++ b/PagerCall/PreActionButtonStyle.swift
@@ -4,10 +4,6 @@ import SwiftUI
 struct PreActionButtonStyle: PrimitiveButtonStyle {
     let preAction: () -> Void
 
-    init(preAction: @escaping () -> Void) {
-        self.preAction = preAction
-    }
-
     func makeBody(configuration: Configuration) -> some View {
         Button(role: configuration.role) {
             preAction()
@@ -20,10 +16,6 @@ struct PreActionButtonStyle: PrimitiveButtonStyle {
 
 struct PreActionButtonStyleModifier: ViewModifier {
     let preAction: () -> Void
-
-    init(preAction: @escaping () -> Void) {
-        self.preAction = preAction
-    }
 
     func body(content: Content) -> some View {
         content.buttonStyle(PreActionButtonStyle(preAction: preAction))


### PR DESCRIPTION
## Summary

Slackpad の CI に倣って、`swiftformat --lint PagerCall` を実行する `Format` ジョブを追加しました（`macos-latest` + `brew install swiftformat`）。

あわせて、チェックを通すためのフォーマット修正を適用しています（SwiftFormat 0.62.1）:

- `PagerDutyAPI.swift`: 末尾カンマの追加
- `PreActionButtonStyle.swift`: 冗長なメモリワイズ init の削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)