### PR TITLE
Validate subdomain input to prevent a crash

### DIFF
--- a/PagerCall/Constants.swift
+++ b/PagerCall/Constants.swift
@@ -2,4 +2,7 @@ import Foundation
 
 enum Constants {
     static let defaultInterval: TimeInterval = 60
+    /// PagerDuty subdomains consist of alphanumerics and hyphens. Restricting input to
+    /// these characters keeps the constructed URL valid and avoids a crash in webBaseURL.
+    static let subdomainAllowedCharacters = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-")
 }

--- a/PagerCall/SettingsView.swift
+++ b/PagerCall/SettingsView.swift
@@ -21,6 +21,12 @@ struct SettingView: View {
                 Vault.apiKey = apiKey
             }
             TextField("Subdomain", text: $subdomain)
+                .onChange(of: subdomain) {
+                    let filtered = String(subdomain.unicodeScalars.filter { Constants.subdomainAllowedCharacters.contains($0) })
+                    if filtered != subdomain {
+                        subdomain = filtered
+                    }
+                }
             TextField("User ID", text: $userID)
             Picker("Region", selection: $region) {
                 ForEach(Region.allCases, id: \.self) { region in


### PR DESCRIPTION
## Problem

`Region.webBaseURL(subdomain:)` interpolates the user-entered subdomain into a URL string and force-unwraps it:

```swift
return URL(string: "https://\(subdomain).pagerduty.com")!
```

The `Subdomain` field (`SettingsView`) is free-form text with no validation. If it contains characters that make `URL(string:)` return `nil` — a space, `%`, `:`, a newline (easy to paste in accidentally) — the force-unwrap **crashes the app** the moment the user opens “My Incidents” / “My On-Call Shifts” from the right-click menu.

Verified crashing inputs: `"foo bar"`, `" leadingspace"`, `"%"`, `"foo:80"`, `"a\nb"`.

## Fix

Filter the `Subdomain` field to alphanumerics and hyphens (valid PagerDuty subdomain characters) via `.onChange`, mirroring the existing clamp on the interval field. Invalid characters are stripped as they are entered, so the constructed URL is always valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)