### PR TITLE
Bump up version

### DIFF
--- a/PagerCall.xcodeproj/project.pbxproj
+++ b/PagerCall.xcodeproj/project.pbxproj
@@ -318,7 +318,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.winebarrel.PagerCall;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -351,7 +351,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.8.1;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.winebarrel.PagerCall;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
This pull request updates the project version number for the PagerCall app. The only change is incrementing the `MARKETING_VERSION` from 1.8.0 to 1.8.1 in the Xcode project file.